### PR TITLE
Apply Capacitor 8, Next.js 16, and React 19 migration fixes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.application'
 
 android {
-    namespace "com.jonathansblog.app"
-    compileSdk rootProject.ext.compileSdkVersion
+    namespace = "com.jonathansblog.app"
+    compileSdk = rootProject.ext.compileSdkVersion
     defaultConfig {
-        applicationId "com.jonathansblog.app"
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 20009
-        versionName "2.09"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        applicationId = "com.jonathansblog.app"
+        minSdkVersion = rootProject.ext.minSdkVersion
+        targetSdkVersion = rootProject.ext.targetSdkVersion
+        versionCode = 20009
+        versionName = "2.09"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
              // Default: https://android.googlesource.com/platform/frameworks/base/+/282e181b58cf72b6ca770dc7ca5f91f135444502/tools/aapt/AaptAssets.cpp#61

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -2,8 +2,8 @@
 
 android {
   compileOptions {
-      sourceCompatibility JavaVersion.VERSION_17
-      targetCompatibility JavaVersion.VERSION_17
+      sourceCompatibility JavaVersion.VERSION_21
+      targetCompatibility JavaVersion.VERSION_21
   }
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density"
             android:name=".MainActivity"
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.8.0'
+        classpath 'com.android.tools.build:gradle:8.13.0'
         classpath 'com.google.gms:google-services:4.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,16 +1,16 @@
 ext {
-    minSdkVersion = 22
-    compileSdkVersion = 35
-    targetSdkVersion = 35
-    androidxActivityVersion = '1.10.0'
-    androidxAppCompatVersion = '1.7.0'
+    minSdkVersion = 24
+    compileSdkVersion = 36
+    targetSdkVersion = 36
+    androidxActivityVersion = '1.11.0'
+    androidxAppCompatVersion = '1.7.1'
     androidxCoordinatorLayoutVersion = '1.3.0'
-    androidxCoreVersion = '1.15.0'
-    androidxFragmentVersion = '1.8.6'
+    androidxCoreVersion = '1.17.0'
+    androidxFragmentVersion = '1.8.9'
     coreSplashScreenVersion = '1.2.0'
-    androidxWebkitVersion = '1.12.0'
+    androidxWebkitVersion = '1.14.0'
     junitVersion = '4.13.2'
-    androidxJunitVersion = '1.2.1'
-    androidxEspressoCoreVersion = '3.6.1'
-    cordovaAndroidVersion = '10.1.1'
+    androidxJunitVersion = '1.3.0'
+    androidxEspressoCoreVersion = '3.7.0'
+    cordovaAndroidVersion = '14.0.1'
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
 	"package": "next build && npx cap sync"
 
   },


### PR DESCRIPTION
Capacitor 8 Android changes:
- variables.gradle: minSdkVersion 22→24, compileSdk/targetSdk 35→36
- variables.gradle: bump all AndroidX library versions to Cap 8 defaults (Activity 1.11.0, AppCompat 1.7.1, Core 1.17.0, Fragment 1.8.9, WebKit 1.14.0, JUnit 1.3.0, Espresso 3.7.0, Cordova 14.0.1)
- build.gradle: AGP 8.8.0 → 8.13.0
- app/build.gradle: add = to all Gradle property assignments (required by AGP)
- capacitor.build.gradle: Java 17 → 21 (auto-updated by cap sync)
- AndroidManifest.xml: add navigation|density to configChanges (Cap 7+8)

Next.js 16 change:
- package.json: replace "next lint" with "eslint ." (next lint removed in 16)

https://claude.ai/code/session_01QZTTf7vX6U18WbWK8pHHHZ